### PR TITLE
Fixed get_data(dataset.py) for REAL 8 elements

### DIFF
--- a/nefis/dataset.py
+++ b/nefis/dataset.py
@@ -390,7 +390,6 @@ class Nefis(object):
         # convert to typed array
         data = np.fromstring(buffer_res, dtype=dtype)
         # return shaped array
-        print(data)
         return data.reshape(elm_dimensions[::-1])
 
     def dump_json(self):

--- a/nefis/dataset.py
+++ b/nefis/dataset.py
@@ -42,6 +42,7 @@ variables:
 
 class NefisException(Exception):
     """A nefis exception"""
+
     def __init__(self, message, status):
         super(Exception, self).__init__(message)
         self.status = status
@@ -81,7 +82,6 @@ class Variable(object):
         )
 
 
-
 def wrap_error(func):
     """wrap a nefis function to raise an error"""
     @functools.wraps(func)
@@ -114,6 +114,7 @@ class NefisJSONEncoder(bokeh.core.json_encoder.BokehJSONEncoder):
 
 class Nefis(object):
     """Nefis file"""
+
     def __init__(self, def_file, ac_type=b'r', coding=b' '):
         """dat file is expected to be named .dat instead of .def"""
 
@@ -369,20 +370,20 @@ class Nefis(object):
         )
         # lookup data type
         datatype = elm_type.strip().upper()
-        if  datatype == 'CHARACTE':
+        if datatype == 'CHARACTE':
             dtype = bytes
         elif datatype == 'REAL':
             if elm_single_byte == 4:
                 dtype = np.float32
             elif elm_single_byte == 8:
                 dtype = np.float64
-        elif datatype == 'INTEGER': 
+        elif datatype == 'INTEGER':
             if elm_single_byte == 4:
                 dtype = np.int32
             elif elm_single_byte == 8:
                 dtype = np.int64
         else:
-            raise ValueError()
+            raise ValueError('Invalid Datatype: {} {}'.format(elm_type.strio(), elm_single_byte))
         if dtype is bytes:
             # return bytes
             return buffer_res.rstrip()

--- a/nefis/dataset.py
+++ b/nefis/dataset.py
@@ -19,9 +19,14 @@ logger = logging.getLogger(__name__)
 MAXDIMS = 5
 MAXGROUPS = 100
 MAXELEMENTS = 1000
-DTYPES = {
+DTYPES32 = {
     'REAL': np.float32,
     'INTEGER': np.int32,
+    'CHARACTE': bytes
+}
+DTYPES64 = {
+    'REAL': np.float64,
+    'INTEGER': np.int64,
     'CHARACTE': bytes
 }
 
@@ -375,7 +380,12 @@ class Nefis(object):
             length
         )
         # lookup data type
-        dtype = DTYPES[elm_type.strip()]
+        if elm_single_byte == 4:
+            dtype = DTYPES32[elm_type.strip()]
+        elif elm_single_byte == 8:
+            dtype = DTYPES64[elm_type.strip()]
+        else:
+            raise ValueError("Element type is not 32/64 bits")
         if dtype is bytes:
             # return bytes
             return buffer_res.rstrip()

--- a/nefis/dataset.py
+++ b/nefis/dataset.py
@@ -19,17 +19,6 @@ logger = logging.getLogger(__name__)
 MAXDIMS = 5
 MAXGROUPS = 100
 MAXELEMENTS = 1000
-DTYPES32 = {
-    'REAL': np.float32,
-    'INTEGER': np.int32,
-    'CHARACTE': bytes
-}
-DTYPES64 = {
-    'REAL': np.float64,
-    'INTEGER': np.int64,
-    'CHARACTE': bytes
-}
-
 
 dump_tmpl = """
 nefis ${ds.def_file} {
@@ -351,7 +340,6 @@ class Nefis(object):
          elm_count,
          elm_dimensions) = result
         logger.info('got info: %s', result)
-
         usr_index = np.zeros((5, 3), dtype=np.int32)
         # first timestep:  0 -> 1 based
         usr_index[0, 0] = t + 1
@@ -380,18 +368,28 @@ class Nefis(object):
             length
         )
         # lookup data type
-        if elm_single_byte == 4:
-            dtype = DTYPES32[elm_type.strip()]
-        elif elm_single_byte == 8:
-            dtype = DTYPES64[elm_type.strip()]
+        datatype = elm_type.strip().upper()
+        if  datatype == 'CHARACTE':
+            dtype = bytes
+        elif datatype == 'REAL':
+            if elm_single_byte == 4:
+                dtype = np.float32
+            elif elm_single_byte == 8:
+                dtype = np.float64
+        elif datatype == 'INTEGER': 
+            if elm_single_byte == 4:
+                dtype = np.int32
+            elif elm_single_byte == 8:
+                dtype = np.int64
         else:
-            raise ValueError("Element type is not 32/64 bits")
+            raise ValueError()
         if dtype is bytes:
             # return bytes
             return buffer_res.rstrip()
         # convert to typed array
         data = np.fromstring(buffer_res, dtype=dtype)
         # return shaped array
+        print(data)
         return data.reshape(elm_dimensions[::-1])
 
     def dump_json(self):


### PR DESCRIPTION
Fixed get_data for REAL 8 elements,  previous version allowed just REAL 4.
The issue happened when I tried to get the following element from trim-*:
'XCOR', 'YCOR', 'YZ'. Sorry I couldn't create a test.